### PR TITLE
support symfony5 (TranslationInterface now in /Contracts)

### DIFF
--- a/Form/Type/LocationRegionType.php
+++ b/Form/Type/LocationRegionType.php
@@ -7,7 +7,7 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\Translation\TranslatorInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * @author Christian Raue <christian.raue@gmail.com>

--- a/Form/Type/TopicCategoryType.php
+++ b/Form/Type/TopicCategoryType.php
@@ -7,7 +7,7 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\Translation\TranslatorInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * @author Christian Raue <christian.raue@gmail.com>

--- a/Form/Type/VehicleEngineType.php
+++ b/Form/Type/VehicleEngineType.php
@@ -7,7 +7,7 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\Translation\TranslatorInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * @author Christian Raue <christian.raue@gmail.com>

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
 	"name": "craue/formflow-demo-bundle",
 	"type": "symfony-bundle",
 	"description": "Example code showcasing the features of CraueFormFlowBundle.",
-	"keywords": ["form", "wizard", "step", "demo", "symfony3", "symfony4"],
+	"keywords": ["form", "wizard", "step", "demo", "symfony3", "symfony4","symfony5"],
 	"homepage": "https://github.com/craue/CraueFormFlowDemoBundle",
 	"license": "MIT",
 	"authors": [
@@ -12,14 +12,14 @@
 		}
 	],
 	"require": {
-		"craue/formflow-bundle": "~3.2@dev",
+		"craue/formflow-bundle": "~3.3",
 		"doctrine/orm": "^2.5.2",
-		"symfony/symfony": "~3.4|~4.1"
+		"symfony/symfony": "~3.4|~4.1|~5.0"
 	},
 	"require-dev": {
 		"doctrine/instantiator": "^1.0.5",
 		"phpunit/phpunit": "^6.5.13|^7.5.1",
-		"symfony/phpunit-bridge": "~3.4|~4.1"
+		"symfony/phpunit-bridge": "~3.4|~4.1|~5.0"
 	},
 	"minimum-stability": "stable",
 	"autoload": {


### PR DESCRIPTION
Bumped the demo to use 3.3 (congrats on the release!), and now supporting Symfony5 in the demo bundle.